### PR TITLE
Add support to parse pids with underscore

### DIFF
--- a/lib/fluent/plugin/parser_logplex.rb
+++ b/lib/fluent/plugin/parser_logplex.rb
@@ -4,7 +4,7 @@ module Fluent
       # Parses syslog-formatted messages[1], framed using syslog TCP protocol octet counting framing method[2]
       # [1] https://tools.ietf.org/html/rfc5424#section-6
       # [2] https://tools.ietf.org/html/rfc6587#section-3.4.1
-      HTTPS_REGEXP = /^([0-9]+)\s+\<(?<pri>[0-9]+)\>[0-9]* (?<time>[^ ]*) (?<drain_id>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*) (?<pid>[a-zA-Z0-9\.]+)? *- *(?<message>.*)$/
+      HTTPS_REGEXP = /^([0-9]+)\s+\<(?<pri>[0-9]+)\>[0-9]* (?<time>[^ ]*) (?<drain_id>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*) (?<pid>[a-zA-Z0-9_\.]+)? *- *(?<message>.*)$/
 
       FACILITY_MAP = Fluent::Plugin::SyslogInput::FACILITY_MAP
       # Constant was renamed in 1.7.3.


### PR DESCRIPTION
This allow us to parse logs like this:

```
228 <190>1 2021-02-20T01:53:42.461349+00:00 host app worker_twitter_internal.4 - [2021-02-20 01:53:42,460: INFO/ForkPoolWorker-1] twitter_poller[08903b9d-e42d-46fa-aa6d-ff7392cc995d]: |2756728:20210218005635:1|Tweet from same month
```